### PR TITLE
Provide optional session object to HttpDriver

### DIFF
--- a/aiovk/drivers.py
+++ b/aiovk/drivers.py
@@ -66,10 +66,13 @@ class BaseDriver:
 
 
 class HttpDriver(BaseDriver):
-    def __init__(self, timeout=10, loop=None):
+    def __init__(self, timeout=10, loop=None, session=None):
         super().__init__(timeout, loop)
-        self.session = aiohttp.ClientSession(
-            response_class=CustomClientResponse, loop=loop)
+        if not session:
+            self.session = aiohttp.ClientSession(
+                response_class=CustomClientResponse, loop=loop)
+        else:
+            self.session = session
 
     async def json(self, url, params, timeout=None):
         with aiohttp.Timeout(timeout or self.timeout):


### PR DESCRIPTION
Actually everything is described here [asynchronous aiohttp requests fails, but synchronous requests succeed
](https://stackoverflow.com/questions/29827642/asynchronous-aiohttp-requests-fails-but-synchronous-requests-succeed), and it would be great to have an ability to disable `verify_ssl`

I work with my code, and everything is fine:

```
loop = get_event_loop()

connector = aiohttp.TCPConnector(verify_ssl=False)
session = aiohttp.ClientSession(connector=connector)
vk_driver = HttpDriver(loop=loop, session=session)
```