### PR TITLE
Use async_timeout.timeout instead of aiohttp.Timeout

### DIFF
--- a/aiovk/drivers.py
+++ b/aiovk/drivers.py
@@ -1,5 +1,6 @@
 import aiohttp
 from aiohttp import hdrs
+import async_timeout
 from multidict import CIMultiDict
 from multidict import CIMultiDictProxy
 
@@ -61,7 +62,7 @@ class BaseDriver:
         '''
         raise NotImplementedError
 
-    def close(self):
+    async def close(self):
         raise NotImplementedError
 
 
@@ -75,27 +76,27 @@ class HttpDriver(BaseDriver):
             self.session = session
 
     async def json(self, url, params, timeout=None):
-        with aiohttp.Timeout(timeout or self.timeout):
+        with async_timeout.timeout(timeout or self.timeout):
             async with self.session.get(url, params=params) as response:
                 return await response.json()
 
     async def get_text(self, url, params, timeout=None):
-        with aiohttp.Timeout(timeout or self.timeout):
+        with async_timeout.timeout(timeout or self.timeout):
             response = await self.session.get(url, params=params)
             return response.status, await response.text()
 
     async def get_bin(self, url, params, timeout=None):
-        with aiohttp.Timeout(timeout or self.timeout):
+        with async_timeout.timeout(timeout or self.timeout):
             response = await self.session.get(url, params=params)
             return await response.read()
 
     async def post_text(self, url, data, timeout=None):
-        with aiohttp.Timeout(timeout or self.timeout):
+        with async_timeout.timeout(timeout or self.timeout):
             response = await self.session.post(url, data=data)
             return response.url, await response.text()
 
-    def close(self):
-        self.session.close()
+    async def close(self):
+        await self.session.close()
 
 
 if ProxyConnector is not None:

--- a/aiovk/mixins.py
+++ b/aiovk/mixins.py
@@ -25,8 +25,8 @@ class LimitRateDriverMixin:
     async def post_text(self, *args, **kwargs):
         return await super().post_text(*args, **kwargs)
 
-    def close(self):
-        super().close()
+    async def close(self):
+        await super().close()
         self._queue.canel()
 
 

--- a/aiovk/sessions.py
+++ b/aiovk/sessions.py
@@ -23,10 +23,10 @@ class TokenSession:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Closes session after usage of context manager with Session"""
-        return self.close()
+        return await self.close()
 
-    def close(self):
-        self.driver.close()
+    async def close(self):
+        await self.driver.close()
 
     async def make_request(self, method_request, timeout=None):
         params = method_request._method_args


### PR DESCRIPTION
Aiohttp dropped support of its own `Timeout` class in 3.0.0 so to support aiohttp 3.x we need to use `async_timeout.timeout` instead.