### PR TITLE
Support iteration over LongPoll objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,13 @@ Use Session object
     >>> await lp.get_pts(need_ts=True)  # return pts, ts
     191231223, 1820350345
 
+You can iterate over events
+
+.. code-block:: python
+   >>> async for event in lp.iter():
+   ...     print(event)
+   [...,...]
+
 Notice that ``wait`` value only for long pool connection.
 
 Real pause could be more ``wait`` time because of need time
@@ -242,6 +249,13 @@ Use Session object
     191231223
     >>> await lp.get_pts(need_ts=True)  # return pts, ts
     191231223, 1820350345
+
+BotsLongPoll supports iterating too
+
+.. code-block:: python
+   >>> async for event in lp.iter():
+   ...     print(event)
+   {"type":..., "object": {...}}
 
 Notice that ``wait`` value only for long pool connection.
 

--- a/aiovk/longpoll.py
+++ b/aiovk/longpoll.py
@@ -87,6 +87,12 @@ class BaseLongPoll(ABC):
             self.base_url = None
 
         return await self.wait()
+    
+    async def iter(self):
+        while True:
+            updates = await self.wait()
+            for event in updates["updates"]:
+                yield event
 
     async def get_pts(self, need_ts=False):
         if not self.base_url or not self.pts:


### PR DESCRIPTION
In vk_api library, LongPoll objects supports beautiful iterating with special method `listen()` and `for` cycle. It's very easy to implement it, if we have `wait()` method, so there is very simple implementation. I've tested it with user and group longpoll, and it works fine.
Also updated examples
