### PR TITLE
Fix authorization related to updated implicit flow redirects

### DIFF
--- a/aiovk/parser.py
+++ b/aiovk/parser.py
@@ -1,3 +1,4 @@
+import re
 import html.parser
 import urllib.parse
 
@@ -84,3 +85,16 @@ class AccessPageParser(html.parser.HTMLParser):
             for name, value in attrs:
                 if name == 'action':
                     self.url = value
+
+
+class AuthRedirectPageParser(html.parser.HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.location = ''
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'meta':
+            attrs = dict(attrs)
+            if attrs.get('http-equiv') == 'refresh':
+                content = attrs['content']
+                self.location = re.findall(r'URL=(.*)$', content)[0]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 
 from setuptools import setup, find_packages
 
-with open('README.rst', 'r') as f:
+with open('README.rst', 'r', encoding='utf8') as f:
     readme = f.read()
 
 with open('requirements.txt') as f:

--- a/tests/responses/auth_redirect.jinja2
+++ b/tests/responses/auth_redirect.jinja2
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>VK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="0; URL={{ redirect_url }}#access_token={{ access_token }}&amp;expires_in={{ expires_in }}&amp;user_id={{ user_id }}">
+    <script>location.href='{{ redirect_url }}#access_token={{ access_token }}&expires_in={{ expires_in }}&user_id={{ user_id }}';</script>
+</head>
+<body>Переадресация...</body>
+</html>


### PR DESCRIPTION
Looks like vk.com changed authorization redirect flow on their side. After login/pass been sent to server it does not redirect to `redirect_url` directly but shows proxy page with `auth_redirect` path which includes correct client-side `redirect_url`.

Changes:
- Support of new flow was added.
- Tests was updated to emulate new authorization flow.

Minor changes:
- Fix **README.rst** reading from **setup.py**  problem which did not allow using pip install `aiovk` as local egg package in machine with non unicode locale as default.

**Important**: implicit flow vk authorization doesn't work at all without the current fix.